### PR TITLE
Upgraded to Electron@10 to fix JS requirements

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "devDependencies": {
     "app-module-path": "^2.2.0",
     "auto-launch": "^5.0.1",
-    "electron": "^1.4.15",
+    "electron": "^10.1.3",
     "electron-builder": "^11.7.0",
     "electron-packager": "^8.5.0",
     "electron-prebuilt": "^1.4.13",


### PR DESCRIPTION
Evernote recently released a new version which doesn't support Electron@1 due to newer JS functionality

![Selection_228](https://user-images.githubusercontent.com/902488/95165329-9ef45680-0760-11eb-83e5-1b932e72c956.png)

In this PR:

- Upgraded to Electron@10 to fix JS requirements
    - We couldn't commit `node_modules` changes due to the `electron` binary being over 100MB which exceeds GitHub requirements